### PR TITLE
Incorrect link used for last item in pager. Link replaced for correct…

### DIFF
--- a/templates/navigation/asu-pager.html.twig
+++ b/templates/navigation/asu-pager.html.twig
@@ -72,7 +72,7 @@
         {% if items.last.href != last_pages_page.href %}
           <li class="page-item pager__item pager__item--ellipsis disabled" role="presentation"><span class="page-link">&hellip;</span></li>
           <li class="page-item pager__item">
-            <a href="{{ items.first.href }}" title="{{ 'Go to last page'|t }}"class="page-link">{{ last_page }}</a>
+            <a href="{{ items.last.href }}" title="{{ 'Go to last page'|t }}"class="page-link">{{ last_page }}</a>
           </li>
         {% endif %}
       {% endif %}


### PR DESCRIPTION
… value.

The incorrect value for the link was shown for the last element in the pager when set to ellipsis.