### PR TITLE
REmove negative margin from close button on mobile.

### DIFF
--- a/src/components/banners/_banners.scss
+++ b/src/components/banners/_banners.scss
@@ -28,3 +28,14 @@
     border: none;
   }
 }
+
+// Media Queries
+.banner {
+  // Mobile tweaks. 576px
+  @media screen and (max-width: $uds-breakpoint-sm) {
+    .banner-close {
+      margin-top: 0;
+      margin-right: 0;
+    }
+  }
+}


### PR DESCRIPTION
The close icons were changed to FA5. This required some css to override original functionality. This corrects an issue on mobile only.