### PR TITLE
WS2-413: Fix width issue on breadcrumb

### DIFF
--- a/src/components/breadcrumb/_breadcrumb.scss
+++ b/src/components/breadcrumb/_breadcrumb.scss
@@ -1,5 +1,11 @@
 @import '../../sass/extends/breadcrumb';
 
+.block-webspark-module-asu-breadcrumb {
+  nav {
+    max-width: 1200px;
+  }
+}
+
 ol.breadcrumb.bg-white {
   padding-left: 0;
 }

--- a/src/components/breadcrumb/_breadcrumb.scss
+++ b/src/components/breadcrumb/_breadcrumb.scss
@@ -6,6 +6,6 @@
   }
 }
 
-ol.breadcrumb.bg-white {
+ol.breadcrumb {
   padding-left: 0;
 }


### PR DESCRIPTION
The breadcrumb <nav> has a container class. This container I believe should be 1200px. When applied to the breadcrumb it is actually 1220px. I have corrected this for the breadcrumb only. Will report this issue back to Unity in case something has broken their end. Removed padding for all colors including white.