### PR TITLE
ws2-477: fix padding on story hero title region.

### DIFF
--- a/src/components/breadcrumb/_breadcrumb.scss
+++ b/src/components/breadcrumb/_breadcrumb.scss
@@ -1,5 +1,12 @@
 @import '../../sass/extends/breadcrumb';
 
-ol.breadcrumb.bg-white {
-  padding-left: 0;
+.block-webspark-module-asu-breadcrumb {
+  .breadcrumbs {
+  }
+  nav {
+    max-width: 1200px;
+    ol.breadcrumb {
+      padding-left: 0;
+    }
+  }
 }

--- a/src/components/layouts/layouts.scss
+++ b/src/components/layouts/layouts.scss
@@ -1,0 +1,7 @@
+.article.article--full {
+  .layout__region.layout__region--first {
+    .container {
+      max-width: 992px;
+    }
+  }
+}

--- a/src/components/story-hero/story-hero.scss
+++ b/src/components/story-hero/story-hero.scss
@@ -1,7 +1,4 @@
 .uds-story-hero {
-  .content {
-    padding: 0.75rem;
-  }
   img {
     width: 100%;
   }

--- a/src/components/story-hero/story-hero.scss
+++ b/src/components/story-hero/story-hero.scss
@@ -1,4 +1,7 @@
 .uds-story-hero {
+  .content {
+    padding: 0.75rem;
+  }
   img {
     width: 100%;
   }

--- a/src/sass/bootstrap-asu-extends.scss
+++ b/src/sass/bootstrap-asu-extends.scss
@@ -31,6 +31,7 @@
 @import 'extends/image-text-block';
 @import 'extends/images';
 @import 'extends/inset-box';
+@import '../components/layouts/layouts';
 @import 'extends/list';
 @import 'extends/media_embed';
 @import 'extends/misc';

--- a/templates/layouts/onecol-article-hero-section.html.twig
+++ b/templates/layouts/onecol-article-hero-section.html.twig
@@ -11,7 +11,7 @@
           <div class="content">
           {% for key, item in content.first %}
             {% if not loop.first %}
-              {{ item.content }}
+              <div class="container">{{ item.content }}</div>
             {% endif %}
           {% endfor %}
           </div>


### PR DESCRIPTION
Added div with a container class to wrap h1 as it was not scaling fluidly and consistently with the breadcrumb. Restricted the container width to 992px on articles only. This is to ensure the text or other components align with the heading and breadcrumb.