### PR TITLE
ws2-478: Remove margin from hero bottom. Break text when continuous s…

### DIFF
--- a/src/components/banners/_banners.scss
+++ b/src/components/banners/_banners.scss
@@ -1,1 +1,5 @@
 @import '../../sass/extends/banners';
+
+.banner__text {
+  word-break: break-all;
+}

--- a/src/components/heroes/heroes.twig
+++ b/src/components/heroes/heroes.twig
@@ -1,4 +1,4 @@
-<div class="uds-hero uds-hero-{{ size }} mb-4"
+<div class="uds-hero uds-hero-{{ size }}"
      style="background-image: linear-gradient(180deg, #19191900 0%, #191919c9 100%), url({{ hero_background }});">
   <div class="container uds-hero-container">
     {# Headings Template #}


### PR DESCRIPTION
Remove margin from hero bottom. Break text when continuous string of characters is pasted into a textarea on notification banners.