### PR TITLE
Drupal provides an extra status for alerts.

### DIFF
--- a/src/components/alerts/alert.twig
+++ b/src/components/alerts/alert.twig
@@ -35,6 +35,9 @@
   {% if type == 'error' %}
     {% set icon = 'fa-exclamation-triangle' %}
   {% endif %}
+  {% if type == 'danger' %}
+    {% set icon = 'fa-exclamation-triangle' %}
+  {% endif %}
 
   <div class="alert-icon"><i class="fas fa-2x {{ icon }}"></i></div>
   <div class="alert-content">


### PR DESCRIPTION
Drupal provides four status message types in D9. Currently we do not have a status for danger in css. Font awesome provides an icon for 'error' which is also used for 'danger'. I have added the status 'danger' to the template using the same icon as 'error' until an alternative is found so we don't display a faulty icon.

@imorale2 This needs a discussion