### PR TITLE
Issue-119 (NOJIRA) - Removed field.html.twig; Added base field--block…

### DIFF
--- a/templates/field/field--block-content.html.twig
+++ b/templates/field/field--block-content.html.twig
@@ -1,3 +1,3 @@
 {% for item in items %}
-  {{ item.content }}
+    {{ item.content }}
 {% endfor %}

--- a/templates/field/field--paragraph.html.twig
+++ b/templates/field/field--paragraph.html.twig
@@ -1,0 +1,3 @@
+{% for item in items %}
+    {{ item.content }}
+{% endfor %}


### PR DESCRIPTION
Removed field.html.twig; Added base field--block-content, field--paragraph Twig files (for now)

From Google Doc:

"I caught this while building a new site and affects ALL field output when using the Renovation theme.

The TWIG file is only outputting the content with
{{ item.content }}. Not only does that strip away any opportunity to theme any field manually (pros/cons to remove excessive <div>s), it breaks Drupal’s UI really badly because it completely ignores settings changes when working with fields in Drupal’s UI. Labels, label positioning, prefix, suffix, etc. are all ignored. 

Solution: I recommend removing the field.html.twig override and instead whitelisting Field template overrides (when necessary)."