### PR TITLE
CSS overrides for ckeditor tooltips.

### DIFF
--- a/css/ckeditor-override.css
+++ b/css/ckeditor-override.css
@@ -45,3 +45,40 @@ ol ol {
   display: block;
   width: 100%;
 }
+
+/*Overrides for Tool Tip*/
+.uds-tooltip .fa-stack {
+  height: 1em;
+  width: 1.5em;
+}
+.uds-tooltip .svg-inline--fa.fa-stack-2x {
+  height: 2em;
+  width: 2em;
+}
+.uds-tooltip:hover .fa-stack .fa-circle {
+  fill: #00b0f3;
+}
+.uds-tooltip-white .fa-stack .fa-circle {
+  fill: #d0d0d0;
+}
+.uds-tooltip-white .fa-stack .fa-info {
+  fill: #ffffff;
+}
+.uds-tooltip-base-gray .fa-stack .fa-circle {
+  fill: #bfbfbf;
+}
+.uds-tooltip-base-gray .fa-stack .fa-info {
+  fill: #fafafa;
+}
+.uds-tooltip-gray .fa-stack .fa-circle {
+  fill: #bfbfbf;
+}
+.uds-tooltip-gray .fa-stack .fa-info {
+  fill: #e8e8e8;
+}
+.uds-tooltip-dark .fa-stack .fa-circle {
+  color: #747474;
+}
+.uds-tooltip-dark .fa-stack .fa-info {
+  color: #191919;
+}

--- a/src/components/tooltips/_tooltips.scss
+++ b/src/components/tooltips/_tooltips.scss
@@ -4,3 +4,72 @@
     margin-left: 2.5rem;
   }
 }
+
+// Overrides as Drupal converts to SVG.
+.formatted-text {
+  .uds-tooltip {
+    .svg-inline--fa.fa-stack-2x {
+      height: 2em;
+      width: 2em;
+    }
+
+    // Turn tooltip icon blue on hover
+    &:hover {
+      .fa-stack .fa-circle {
+        fill: $uds-color-font-light-info;
+      }
+    }
+
+    // Default white.
+    &-white {
+      .fa-stack {
+        .fa-circle {
+          fill: $uds-color-base-gray-3;
+        }
+
+        .fa-info {
+          fill: $uds-color-base-white;
+        }
+      }
+    }
+
+    // Base gray colors
+    &-base-gray {
+      .fa-stack {
+        .fa-circle {
+          fill: $uds-color-base-gray-4;
+        }
+
+        .fa-info {
+          fill: $uds-color-base-gray-1;
+        }
+      }
+    }
+
+    // Gray colors
+    &-gray {
+      .fa-stack {
+        .fa-circle {
+          fill: $uds-color-base-gray-4;
+        }
+
+        .fa-info {
+          fill: $uds-color-background-gray;
+        }
+      }
+    }
+
+    // Dark colors
+    &-dark {
+      .fa-stack {
+        .fa-circle {
+          fill: $uds-color-base-gray-5;
+        }
+
+        .fa-info {
+          fill: $uds-color-font-dark-base;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Font Awesome <i> tags get converted to SVG's in CKEditor. This PR uses the fill attribute to set colors rather than color. The excess space around the icon has been removed to allow the icon to sit within the text more comfortably.