### PR TITLE
WS2-443: Hide required star on image size selection.

### DIFF
--- a/src/components/layout-builder-form-overrides/_layout-builder-form-overrides.scss
+++ b/src/components/layout-builder-form-overrides/_layout-builder-form-overrides.scss
@@ -1,0 +1,10 @@
+/* Hide the red star on the image size field. */
+
+#drupal-off-canvas {
+  .field--name-field-image-size .form-item-settings-block-form-field-image-size .form-required:after {
+    display: none!important;
+  }
+}
+
+
+

--- a/src/sass/bootstrap-asu-extends.scss
+++ b/src/sass/bootstrap-asu-extends.scss
@@ -31,6 +31,7 @@
 @import 'extends/image-text-block';
 @import 'extends/images';
 @import 'extends/inset-box';
+@import '../components/layout-builder-form-overrides/layout-builder-form-overrides';
 @import '../components/layouts/layouts';
 @import '../components/lists/lists';
 @import 'extends/media_embed';


### PR DESCRIPTION
Image block displays a required star due to being set with a default value. This PR hides the red star.