### PR TITLE
WS2-677: Overrides to correct alignment on Article content types.

### DIFF
--- a/src/components/story-hero/story-hero.scss
+++ b/src/components/story-hero/story-hero.scss
@@ -1,6 +1,35 @@
 .uds-story-hero {
+  .content {
+    .container {
+      /* Remove padding on story containers at desktop to achieve correct alignment. */
+      @media screen and (min-width: $uds-breakpoint-xl) {
+        padding: 0;
+      }
+    }
+  }
   img {
+    /* Set width 100% in case image is too small. */
     width: 100%;
+  }
+}
+/* set the correct content widths for stories. */
+.article.article--full {
+  .layout__fixed-width {
+    .layout__region {
+      margin: 0 102px;
+      @media screen and (max-width: $uds-breakpoint-sm) {
+        margin: 0 20px;
+      }
+      @media screen and (max-width: $uds-breakpoint-md) {
+        margin: 0 16px;
+      }
+      @media screen and (max-width: $uds-breakpoint-lg) {
+        margin: 0 16px;
+      }
+      @media screen and (max-width: $uds-breakpoint-xl) {
+        margin: 0 83px;
+      }
+    }
   }
 }
 

--- a/src/components/story-hero/story-hero.scss
+++ b/src/components/story-hero/story-hero.scss
@@ -17,17 +17,17 @@
   .layout__fixed-width {
     .layout__region {
       margin: 0 102px;
-      @media screen and (max-width: $uds-breakpoint-sm) {
-        margin: 0 20px;
-      }
-      @media screen and (max-width: $uds-breakpoint-md) {
-        margin: 0 16px;
+      @media screen and (max-width: $uds-breakpoint-xl) {
+        margin: 0 83px;
       }
       @media screen and (max-width: $uds-breakpoint-lg) {
         margin: 0 16px;
       }
-      @media screen and (max-width: $uds-breakpoint-xl) {
-        margin: 0 83px;
+      @media screen and (max-width: $uds-breakpoint-md) {
+        margin: 0 16px;
+      }
+      @media screen and (max-width: $uds-breakpoint-sm) {
+        margin: 0 20px;
       }
     }
   }


### PR DESCRIPTION
Fixes in this PR

- Add margins to fixed width layout regions specifically for Article content type to align with storybook.
- Remove padding from Article type on containers for title and breadcrumb to align correctly with Storybook.