### PR TITLE
WS2-707: Fixes for image embeds.

### DIFF
--- a/css/ckeditor-override.css
+++ b/css/ckeditor-override.css
@@ -82,3 +82,15 @@ ol ol {
 .uds-tooltip-dark .fa-stack .fa-info {
   color: #191919;
 }
+
+/* Media library. Positions the edit button top left of inserted image.*/
+button.media-library-item__edit {
+  position: absolute;
+  left: 10px;
+  top: 10px;
+}
+
+/* Figcaption uses table layout in CK which conflicts with renovation css. */
+.caption > figcaption {
+  display: block;
+}

--- a/src/components/image/_images.scss
+++ b/src/components/image/_images.scss
@@ -1,0 +1,22 @@
+@import '../../sass/extends/images';
+
+.uds-img {
+  /* Add margin to bottom of image with boxshadow.*/
+  &.uds-img-drop-shadow {
+    margin-bottom: 1em;
+  }
+}
+
+/* Apply border to embedded image. */
+.embedded-media {
+  img {
+    border: 1px solid $uds-color-base-gray-3;
+  }
+}
+
+/* Figcaption Overrides CKeditor. */
+.caption-drupal-media {
+  img {
+    border: 1px solid $uds-color-base-gray-3;
+  }
+}

--- a/src/sass/bootstrap-asu-extends.scss
+++ b/src/sass/bootstrap-asu-extends.scss
@@ -29,7 +29,7 @@
 @import 'extends/image-background-with-cta';
 @import 'extends/image-overlap';
 @import 'extends/image-text-block';
-@import 'extends/images';
+@import '../components/image/images';
 @import 'extends/inset-box';
 @import '../components/layouts/layouts';
 @import '../components/lists/lists';


### PR DESCRIPTION
This PR adds a border to embedded images. There is also a fix for the caption displaying in Layout Builder 40px wide. The error came from CKeditor which was using table-cell to display the caption. This has been overridden in the CKeditor overrides css file.