### PR TITLE
Add jquery.once dependency.

### DIFF
--- a/renovation.libraries.yml
+++ b/renovation.libraries.yml
@@ -8,6 +8,7 @@ style:
   dependencies:
     - core/jquery
     - core/drupal
+    - core/jquery.once
 renovation.chartjs:
   remote: https://github.com/chartjs/Chart.js
   version: 3.2.0


### PR DESCRIPTION
For annon users, this library doesn't load by default so we must add it as a dependency.