### PR TITLE
WS2-302: Overrides required for CKE to use spans for tooltips as div cannot be embedded in <p> element.

### DIFF
--- a/css/ckeditor-override.css
+++ b/css/ckeditor-override.css
@@ -83,7 +83,8 @@ ol ol {
   color: #191919;
 }
 
-/* Media library. Positions the edit button top left of inserted image.*/
+/* Media library. Positions the edit button top left of inserted image as default position breaks the alignment of
+images in ckeditor.*/
 button.media-library-item__edit {
   position: absolute;
   left: 10px;

--- a/src/components/tooltips/_tooltips.scss
+++ b/src/components/tooltips/_tooltips.scss
@@ -1,75 +1,134 @@
 @import '../../sass/extends/tooltips';
-/*.uds-tooltip {
-  .uds-tooltip-text {
-    margin-left: 2.5rem;
+span.uds-tooltip-container {
+  display: inline-block;
+  position: relative;
+  background: transparent;
+
+  button.uds-tooltip {
+    background: none;
+    color: inherit;
+    border: none;
+    padding: 0;
+    font: inherit;
+    cursor: pointer;
+    outline: inherit;
+
+    .fa-circle {
+      color: $uds-color-base-gray-3;
+    }
+
+    .fa-info {
+      color: $uds-color-base-white;
+    }
+
+    .fa-stack > * {
+      font-size: 0.75rem;
+    }
+
+    i {
+      vertical-align: middle;
+    }
+
+    &:hover,
+    &:focus {
+      + span.uds-tooltip-description {
+        visibility: visible;
+      }
+
+      .fa-circle {
+        color: $uds-color-font-light-info;
+      }
+    }
+  }
+
+  button.uds-tooltip-gray-1 {
+    .fa-circle {
+      color: $uds-color-base-gray-4;
+    }
+
+    .fa-info {
+      color: $uds-color-base-gray-1;
+    }
+  }
+
+  button.uds-tooltip-gray {
+    .fa-circle {
+      color: $uds-color-base-gray-4;
+    }
+
+    .fa-info {
+      color: $uds-color-background-gray;
+    }
+  }
+
+  button.uds-tooltip-dark {
+    .fa-circle {
+      color: $uds-color-base-gray-5;
+    }
+
+    .fa-info {
+      color: $uds-color-font-dark-base;
+    }
+  }
+
+  span.uds-tooltip-description {
+    background: #191919 0% 0% no-repeat padding-box;
+    color: $uds-color-base-gray-1;
+    font: normal normal normal 1rem Arial;
+    line-height: 2rem;
+    margin: 0px 5px;
+    max-width: 353px;
+    min-width: 300px;
+    padding: 2rem;
+    position: absolute;
+    left: 40px;
+    top: 0;
+    visibility: hidden;
+    z-index: 1;
+
+    & > span.uds-tooltip-heading {
+      color: $uds-color-base-gray-1;
+      display: block;
+      font: normal normal bold 1rem Arial;
+      letter-spacing: 0px;
+      margin-bottom: 1rem;
+      text-align: left;
+    }
+  }
+
+  span.uds-tooltip-visually-hidden {
+    clip-path: inset(100%);
+    clip: rect(1px, 1px, 1px, 1px);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
   }
 }
 
-// Overrides as Drupal converts to SVG.
-.formatted-text {
-  .uds-tooltip {
-    .svg-inline--fa.fa-stack-2x {
-      height: 2em;
-      width: 2em;
+span.uds-tooltip-bg-white.uds-tooltip-container,
+span.uds-tooltip-container.uds-tooltip-bg-gray-1,
+span.uds-tooltip-container.uds-tooltip-bg-gray {
+  svg.fa-info-circle {
+    color: $uds-color-base-gray-3;
+    &:hover,
+    &:focus {
+      color: $uds-color-font-light-info;
     }
+  }
+}
 
-    // Turn tooltip icon blue on hover
-    &:hover {
-      .fa-stack .fa-circle {
-        fill: $uds-color-font-light-info;
-      }
-    }
-
-    // Default white.
-    &-white {
-      .fa-stack {
-        .fa-circle {
-          fill: $uds-color-base-gray-3;
-        }
-
-        .fa-info {
-          fill: $uds-color-base-white;
-        }
-      }
-    }
-
-    // Base gray colors
-    &-base-gray {
-      .fa-stack {
-        .fa-circle {
-          fill: $uds-color-base-gray-4;
-        }
-
-        .fa-info {
-          fill: $uds-color-base-gray-1;
-        }
-      }
-    }
-
-    // Gray colors
-    &-gray {
-      .fa-stack {
-        .fa-circle {
-          fill: $uds-color-base-gray-4;
-        }
-
-        .fa-info {
-          fill: $uds-color-background-gray;
-        }
-      }
-    }
-
-    // Dark colors
-    &-dark {
-      .fa-stack {
-        .fa-circle {
-          fill: $uds-color-base-gray-5;
-        }
-
-        .fa-info {
-          fill: $uds-color-font-dark-base;
-        }
+span.uds-tooltip-bg-dark.uds-tooltip-container {
+  button.uds-tooltip {
+    background: $uds-color-base-gray-4;
+    border-radius: 100%;
+    height: 32px;
+    svg.fa-info-circle {
+      &:hover,
+      &:focus {
+        color: $uds-color-font-light-info;
       }
     }
   }
-}*/
+}

--- a/src/sass/extends/_media_embed.scss
+++ b/src/sass/extends/_media_embed.scss
@@ -1,38 +1,40 @@
-.align-left.embedded-media {
-  padding: 5px 10px 0 0;
-}
+/* Image centering in Media Embed will not work correctly without this.*/
 
-.align-right.embedded-media {
-  padding: 5px 0 0 10px;
-}
-
-.formatted-text {
-  .align-center {
-    text-align: center;
+.align-center {
+  width: max-content;
+  img {
+    max-width: initial;
   }
 }
 
+/* Required css to match figcaption in CKeditor as Embeds are structured differently to Unity. */
 
-figure.caption-drupal-media {
-    .embedded-media {
-      img {
-        border: 1px solid #d0d0d0;
-      }
-    }
-
-    figcaption {
-      border: 1px solid #d0d0d0;
-      border-top: none;
-      opacity: 1;
-      background: #fff 0% 0% no-repeat padding-box;
-      padding: .75rem;
-      font-size: .75rem;
-      text-align: left;
-      span {
-        color: $uds-color-base-gray-5;
-        max-width: 75ch;
-      }
-    }
-
+figure.caption.caption-drupal-media.align-left {
+  margin-right: 5px;
 }
 
+figure.caption.caption-drupal-media.align-left {
+  margin-left: 5px;
+}
+
+figure.caption-drupal-media {
+  .embedded-media {
+    img {
+      border: 1px solid #d0d0d0;
+    }
+  }
+
+  figcaption {
+    border: 1px solid #d0d0d0;
+    border-top: none;
+    opacity: 1;
+    background: #fff 0% 0% no-repeat padding-box;
+    padding: .75rem;
+    font-size: .75rem;
+    text-align: left;
+    span {
+      color: $uds-color-base-gray-5;
+      max-width: 75ch;
+    }
+  }
+}


### PR DESCRIPTION
Correct alignment issues in/from CKE and position button so it does not break alignment when embedding.

Replacement for https://github.com/ASUWebPlatforms/webspark-theme-renovation/pull/151