### PR TITLE
WS2-893: Revert radio buttons on webforms.

### DIFF
--- a/css/ckeditor-override.css
+++ b/css/ckeditor-override.css
@@ -228,14 +228,12 @@ button.media-library-item__edit {
     margin-left: 205px;
   }
 }
-form.uds-form .form-check input[type=radio] {
-  opacity: 1;
+/* Override for the CKEditor table */
+.uds-table.uds-table-default > table {
+  width: auto;
 }
 
-form.uds-form .form-check input[type=radio]+label:before {
-  content: none;
-}
-
-form.uds-form .form-check input[type=radio]+label:after {
-  content: none;
+.uds-table.uds-table-default table tr :nth-child(n+1) {
+  min-width: unset;
+  max-width: unset;
 }

--- a/src/components/_form-overrides.scss
+++ b/src/components/_form-overrides.scss
@@ -11,3 +11,15 @@ form.uds-form {
     padding-left: $uds-size-spacing-4 !important;
   }
 }
+
+form.uds-form.layout-builder-configure-block .form-check input[type=radio] {
+  opacity: 1;
+}
+
+form.uds-form.layout-builder-configure-block .form-check input[type=radio]+label:before {
+  content: none;
+}
+
+form.uds-form.layout-builder-configure-block .form-check input[type=radio]+label:after {
+  content: none;
+}


### PR DESCRIPTION
This reverts the radio buttons format on webforms and keeps the fixed format on layout overlay forms.

Ref.: https://asudev.jira.com/browse/WS2-893