### PR TITLE
WS2-978: Restore button text color.

### DIFF
--- a/src/components/text/_text.scss
+++ b/src/components/text/_text.scss
@@ -2,7 +2,7 @@
   .block-inline-blocktext-content {
     &.text-white {
       .formatted-text {
-        a {
+        a:not(.btn) {
           color: $uds-color-brand-gold;
         }
       }


### PR DESCRIPTION
@duarte-daniela this fixes the Gold button text color when the text background is Gray 7.