### PR TITLE
WS2-1131: Remove empty icon space.

### DIFF
--- a/src/components/cards/cards.scss
+++ b/src/components/cards/cards.scss
@@ -46,6 +46,12 @@
   }
 }
 
+.uds-card-and-image {
+  i.fa-null {
+    display: none;
+  }
+}
+
 @media only screen and (max-width: $uds-breakpoint-lg) {
   .uds-card-image-and-content-content-container {
     .card-wrapper {


### PR DESCRIPTION
@duarte-daniela @mlsamuelson this removes the space when no card icon was selected.

Ref.: https://asudev.jira.com/browse/WS2-1131