### PR TITLE
WS2-1120: Font Awesome link focus.

### DIFF
--- a/src/components/text/_text.scss
+++ b/src/components/text/_text.scss
@@ -9,3 +9,9 @@
     }
   }
 }
+
+.block-inline-blocktext-content {
+  a {
+    display: inline-block;
+  }
+}


### PR DESCRIPTION
@duarte-daniela @mlsamuelson this fixes the link focus outline in rich text links, including Font Awesome icons as hyperlinks.

Ref.: https://asudev.jira.com/browse/WS2-1120