### PR TITLE
WS2-1162: Include charts_graphs in libraries.yml.

### DIFF
--- a/renovation.libraries.yml
+++ b/renovation.libraries.yml
@@ -9,6 +9,15 @@ style:
     - core/jquery
     - core/drupal
     - core/jquery.once
+
+charts_graphs:
+  js:
+    src/components/charts-and-graphs/charts-and-graphs.js: {}
+  dependencies:
+    - core/jquery
+    - core/drupal
+    - core/jquery.once
+
 renovation.chartjs:
   remote: https://github.com/chartjs/Chart.js
   version: 3.2.0

--- a/src/components/charts-and-graphs/donut.twig
+++ b/src/components/charts-and-graphs/donut.twig
@@ -8,4 +8,4 @@
   </div>
 </div>
 {{ attach_library('renovation/renovation.chartjs') }}
-{{ attach_library('renovation/charts-and-graphs') }}
+{{ attach_library('renovation/charts_graphs') }}


### PR DESCRIPTION
@duarte-daniela @mlsamuelson this fixes the display of Donut charts in Renovation sub-themes. 

Ref.: https://asudev.jira.com/browse/WS2-1162