### PR TITLE
WS2-997: Remove image resize in Card And Image component.

### DIFF
--- a/src/components/cards/card-and-image-parallax.js
+++ b/src/components/cards/card-and-image-parallax.js
@@ -1,4 +1,4 @@
-const initImageParallax = () => {
+(function () {
   const MAGIC_PARALLAX_FACTOR = 1.2;
 
   const scrollHandler = () => {
@@ -25,52 +25,6 @@ const initImageParallax = () => {
         const correct_position =
           default_position * (1 - portion_of_container_scrolled);
         the_image.style.top = correct_position + 'px';
-      }
-    });
-  };
-
-  const image_resizer = (image) => {
-    const container = image.parentNode;
-    const image_starting_width = image.width;
-    const image_starting_height = image.height;
-
-    // First, we want the image to be the width of the screen.
-    let size_change_factor = container.offsetWidth / image_starting_width;
-
-    // Second, if this is too short to allow parallax, given
-    // the size of the container, we scale it up further to
-    // allow MAGIC_PARALLAX_FACTOR amount of parallax. If
-    // we do this we'll also need to shift it left to re-center the image.
-    // TODO: Allow the parallax factor to be set as a property of
-    // the parallax-container div;
-    let new_left_pos = 0;
-    let new_height = image_starting_height * size_change_factor;
-    let new_width = image_starting_width * size_change_factor;
-
-    const parallaxFactor =
-      +image.dataset.parallaxFactor || MAGIC_PARALLAX_FACTOR;
-    if (
-      !image.dataset.noScale &&
-      new_height < container.offsetHeight * parallaxFactor
-    ) {
-      size_change_factor =
-        (container.offsetHeight * parallaxFactor) / new_height;
-
-      new_height *= size_change_factor;
-      new_width *= size_change_factor;
-
-      new_left_pos = ((new_width - container.offsetWidth) / 2) * -1;
-    }
-    image.style.height = new_height + 'px';
-    image.style.left = new_left_pos + 'px';
-  };
-
-  const manage_image_sizes = () => {
-    document.querySelectorAll('.parallax-container img').forEach((image, i) => {
-      if (image.complete) {
-        image_resizer(image);
-      } else {
-        image.onload = () => image_resizer(image);
       }
     });
   };
@@ -102,18 +56,6 @@ const initImageParallax = () => {
     })
   );
 
-  // Window management
-  window.addEventListener('DOMContentLoaded', function () {
-    manage_image_sizes();
-  });
-
-  window.addEventListener('resize', function () {
-    manage_image_sizes();
-  });
-
   window.addEventListener('scroll', scrollHandler);
-};
 
-(function () {
-  initImageParallax();
 }());


### PR DESCRIPTION
@duarte-daniela @mlsamuelson this removes the image resizing in the parallax related functionality.

Ref.: https://asudev.jira.com/browse/WS2-997?focusedCommentId=1397035