### PR TITLE
WS2-603: Fix tooltip display in iPhone.

### DIFF
--- a/src/components/tooltips/tooltips.js
+++ b/src/components/tooltips/tooltips.js
@@ -2,20 +2,16 @@
   jQuery(function () {
     'use strict';
     let element;
-    
-    
     $('button.uds-tooltip').on('click', (_this, e) => {
-      if (element?.is(':focus')) element.trigger('blur');
+      if (element && element.is(':focus')) element.trigger('blur');
       element = element
         ? undefined
         : $(
             `button[aria-describedby=${$(_this)
               .get(0)
               .currentTarget.getAttribute('aria-describedby')}]`
-          );
-    });
-    $('button.uds-tooltip').on('blur', () => {
-      setTimeout(() => (element = undefined));
+        );
+      if (element && !element.is(':focus')) element.trigger('focus');
     });
   });
 }(jQuery));


### PR DESCRIPTION
@duarte-daniela @mlsamuelson this fixes the toolitp display in iPhone.

Ref.: https://asudev.jira.com/browse/WS2-603?focusedCommentId=1397188 