### PR TITLE
WS2-1276: Fix skip-to-main-content issue

### DIFF
--- a/src/sass/content/_theme-tweaks.scss
+++ b/src/sass/content/_theme-tweaks.scss
@@ -1,0 +1,6 @@
+/* Make skip to content link visible upon focus (it was hidden by the ASU
+Header */
+.sr-only-focusable:active, .sr-only-focusable:focus {
+    position: relative;
+    z-index: 1050;
+}

--- a/src/sass/renovation.style.scss
+++ b/src/sass/renovation.style.scss
@@ -66,3 +66,4 @@
 @import "block/block";
 @import "content/node.page";
 @import "content/node.article";
+@import "content/theme-tweaks";

--- a/templates/page/page.html.twig
+++ b/templates/page/page.html.twig
@@ -21,7 +21,7 @@
     {% endif %}
 
     {% if page.content %}
-      <div class="page__content">
+      <div id="skip-to-content" class="page__content">
         {{ page.content }}
       </div>
     {% endif %}

--- a/templates/system/html.html.twig
+++ b/templates/system/html.html.twig
@@ -1,0 +1,48 @@
+{#
+/**
+ * @file
+ * Default theme implementation for the basic structure of a single Drupal page.
+ *
+ * Variables:
+ * - logged_in: A flag indicating if user is logged in.
+ * - root_path: The root path of the current page (e.g., node, admin, user).
+ * - node_type: The content type for the current node, if the page is a node.
+ * - head_title: List of text elements that make up the head_title variable.
+ *   May contain one or more of the following:
+ *   - title: The title of the page.
+ *   - name: The name of the site.
+ *   - slogan: The slogan of the site.
+ * - page_top: Initial rendered markup. This should be printed before 'page'.
+ * - page: The rendered page markup.
+ * - page_bottom: Closing rendered markup. This variable should be printed after
+ *   'page'.
+ * - db_offline: A flag indicating if the database is offline.
+ * - placeholder_token: The token for generating head, css, js and js-bottom
+ *   placeholders.
+ *
+ * @see template_preprocess_html()
+ *
+ * @ingroup themeable
+ */
+#}
+<!DOCTYPE html>
+<html{{html_attributes}}>
+  <head>
+    <head-placeholder token="{{ placeholder_token }}">
+    <title>{{ head_title|safe_join(' | ') }}</title>
+    <css-placeholder token="{{ placeholder_token }}">
+    <js-placeholder token="{{ placeholder_token }}">
+  </head>
+  <body{{attributes}}>
+    {% if logged_in and user.hasPermission('Use the toolbar') %}
+      <a href="#skip-to-content" class="sr-only sr-only-focusable">
+        {{ 'Skip to main content'|t }}
+      </a>
+    {% endif %}
+    {{ page_top }}
+    {{ page }}
+    {{ page_bottom }}
+    <js-bottom-placeholder token="{{ placeholder_token }}">
+  </body>
+</html>
+


### PR DESCRIPTION
I ended up choosing to keep the two different skip-to-main-content links, but employed some logic so that if the toolbar was available, the non-header one would be used. This will bypass all of the links in the toolbar, which will improve the experience regardless of whether a user has toolbar access or not.