### PR TITLE
WS2-1130: Add new template to allow changing the heading element

### DIFF
--- a/templates/field/field--block-content--field-heading--content-image.html.twig
+++ b/templates/field/field--block-content--field-heading--content-image.html.twig
@@ -1,0 +1,22 @@
+{#
+/**
+ * @file
+ * Default template for a field.
+ */
+#}
+
+{%
+  set classes = [
+    bundle|clean_class ~ '__' ~ field_name_clean|clean_class,
+    label_display == 'inline' ? 'd-flex',
+  ]
+%}
+
+{% for item in items %}
+  <div{{ attributes.addClass(classes) }}>
+    {% include '@renovation/headings/heading.twig' with {
+      html_tag: 'h2',
+      heading: item.content['#context'].value,
+    } %}
+  </div>
+{% endfor %}


### PR DESCRIPTION
This PR is part of a larger fix, see https://asudev.jira.com/browse/WS2-1130

This adds a new field template for the heading used by the Content Image Overlap block. This heading is optional, but when it is used, it will always appear as an `h2` element and highlighted gold.