### PR TITLE
WS2 release 2.6.0 fix twig syntax

### DIFF
--- a/templates/field/field--node--title.html.twig
+++ b/templates/field/field--node--title.html.twig
@@ -8,10 +8,10 @@
 {% if not is_inline %}
   {% include "field.html.twig" %}
 {% else %}
-{% for item in items %}
-  {% include '@renovation/headings/heading.twig' with {
-    html_tag : 'h1',
-    heading: item.content['#context'].value,
-  } %}
-{% endfor %}
-
+  {% for item in items %}
+    {% include '@renovation/headings/heading.twig' with {
+      html_tag : 'h1',
+      heading: item.content['#context'].value,
+    } %}
+  {% endfor %}
+{% endif %}


### PR DESCRIPTION
Was getting `Twig\Error\SyntaxError: Unexpected end of template. in Twig\TokenStream->next() (line 17 of /code/web/themes/composer/webspark-theme-renovation/templates/field/field--node--title.html.twig).`