### PR TITLE
Automatically create the config.local.js file

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "A theme based on Radix.",
   "private": true,
   "scripts": {
-    "postinstall": "find node_modules/ -name '*.info' -type f -delete",
+    "postinstall": "find node_modules/ -name '*.info' -type f -delete && cp ./config.js ./config.local.js",
     "dev": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
     "watch": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --watch --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
     "hot": "cross-env NODE_ENV=development webpack-dev-server --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",


### PR DESCRIPTION
This PR is to get a quick conversation going. Right now we have the `config.js` but we need to manually copy it to `config.local.js`. I always forget to do this, so I added some code to the `postinstall` to automatically do it for me.

Is this something that would be useful to everyone, or should I just keep this to my own workflow?

PROS: Don't need to remember to manually create `config.local.js`

CONS: If you have to re-install the theme a lot, you will need to update the `proxy` value each time, assuming that you use the BrowserSync functionality. And since this will create a new `config.local.js` each time, any custom code in here would also need to be added back.