### PR TITLE
WS2-1219: Remove opacity from Table Select form fields inputs

### DIFF
--- a/src/sass/extends/_form-fields.scss
+++ b/src/sass/extends/_form-fields.scss
@@ -98,6 +98,10 @@ form.uds-form {
       opacity: 0;
     }
 
+    .tableselect.form-check-input {
+      opacity: 1;
+    }
+
     // Shared styling for Radios and Checkboxes.
     input[type='radio'],
     input[type='checkbox'] {

--- a/src/sass/extends/_form-fields.scss
+++ b/src/sass/extends/_form-fields.scss
@@ -98,10 +98,6 @@ form.uds-form {
       opacity: 0;
     }
 
-    .tableselect.form-check-input {
-      opacity: 1;
-    }
-
     // Shared styling for Radios and Checkboxes.
     input[type='radio'],
     input[type='checkbox'] {

--- a/src/sass/renovation-extends/_form-fields.scss
+++ b/src/sass/renovation-extends/_form-fields.scss
@@ -1,0 +1,7 @@
+form.uds-form {
+  .form-check {
+    .tableselect.form-check-input {
+      opacity: 1;
+    }
+  }
+}

--- a/src/sass/renovation.style.scss
+++ b/src/sass/renovation.style.scss
@@ -48,7 +48,7 @@
 // -----------------------------------------------------------------------------
 @import "design-tokens/variables";
 @import "bootstrap-asu";
-@import "bootstrap-asu-extends";
+@import "bootstrap-asu-extends"; // NOTE: This is already imported in bootstrap-asu.scss
 
 // Layout
 // -----------------------------------------------------------------------------
@@ -67,3 +67,4 @@
 @import "content/node.page";
 @import "content/node.article";
 @import "content/theme-tweaks";
+@import "renovation-extends/form-fields";


### PR DESCRIPTION
See: https://asudev.jira.com/browse/WS2-1219

Quick CSS fix to prevent the checkbox inputs for the Table Select field type from being transparent.

This code might be in the wrong place.