### PR TITLE
WS2-1525 Adding width and height parameters to footer template, updat…

### DIFF
--- a/templates/block/asu-footer--footer-block.html.twig
+++ b/templates/block/asu-footer--footer-block.html.twig
@@ -23,7 +23,8 @@
             >
               <img
                 src="{{ src_unit_logo }}"
-                alt="ASU University Technology Office Arizona State University."
+                loading="lazy" height="{{ src_unit_logo_height }}" width="{{ src_unit_logo_width }}"
+                alt="Arizona State University."
               />
             </a>
           {% endif %}
@@ -237,7 +238,7 @@
             data-ga-footer="#1 in the u.s. for innovation"
             data-ga-footer-component=""
           >
-            <img src="{{ src_footer_img }}" alt="Number one in the U.S. for innovation. #1 ASU, #2 Stanford, #3 MIT. - U.S. News and World Report, 5 years, 2016-2020">
+            <img src="{{ src_footer_img }}" loading="lazy" height="{{ src_footer_img_height }}" width="{{ src_footer_img_width }}" alt="Number one in the U.S. for innovation. #1 ASU, #2 Stanford, #3 MIT. - U.S. News and World Report, 8 years, 2016-2023">
           </a>
         </div>
       </div>


### PR DESCRIPTION
…ing alt text on images

https://asudev.jira.com/browse/WS2-1525

This pull request needs to be reviewed in conjunction with https://github.com/ASUWebPlatforms/webspark-module-asu_footer/pull/20

This change adds the lazy-loading attribute and width and height to two images that are hardcoded into the footer--the default ASU logo and the Innovation lockup. (see screenshots below for the two logos I am talking about)

It also updates/corrects the alt text on the default ASU logo and Innovation Lockup. 

To test, apply this update in conjunction with https://github.com/ASUWebPlatforms/webspark-module-asu_footer/pull/20. Observe that the lazy loading attributes and width and height exist on the footer logos/images. See last screenshot for what you should see in the browser. 

![Screenshot 2023-04-06 at 4 25 13 PM](https://user-images.githubusercontent.com/6909200/230511465-2cd23625-585e-45fc-ae53-71179a7414d5.png)
![Screenshot 2023-04-06 at 4 25 10 PM](https://user-images.githubusercontent.com/6909200/230511520-2b04f45c-24ea-4cb7-8641-4e2e2be3aab4.png)
![Screenshot 2023-04-06 at 4 28 04 PM](https://user-images.githubusercontent.com/6909200/230511730-d27ebc45-5e7e-40e4-ab9d-7f53464c8732.png)
