### PR TITLE
WS2-1574: Fix issue related to quotes.

### DIFF
--- a/src/components/blockquote/blockquote-image.twig
+++ b/src/components/blockquote/blockquote-image.twig
@@ -4,7 +4,7 @@
     <h3>
       <span class="{{ highlight }}">{{ heading }}</span>
     </h3>
-    <p>{{ body_text['#text']|spaceless|replace({'</p><p>': '<br/>', '<p>': '', '</p>': ''})|raw }}</p>
+    <p>{{ body_text['#text']|spaceless|replace({'</p><p>': '<br>'})|striptags('<a><br>')|raw }}</p>
     {% if citation_author is not empty or citation_description is not empty %}
       <div class="citation">
         <div class="citation-content">

--- a/src/components/blockquote/blockquote-image.twig
+++ b/src/components/blockquote/blockquote-image.twig
@@ -4,7 +4,7 @@
     <h3>
       <span class="{{ highlight }}">{{ heading }}</span>
     </h3>
-    <p>{{ body_text['#text']|spaceless|replace({'</p><p>': '</br>', '<p>': '', '</p>': ''})|raw }}</p>
+    <p>{{ body_text['#text']|spaceless|replace({'</p><p>': '<br/>', '<p>': '', '</p>': ''})|raw }}</p>
     {% if citation_author is not empty or citation_description is not empty %}
       <div class="citation">
         <div class="citation-content">

--- a/src/components/blockquote/blockquote-image.twig
+++ b/src/components/blockquote/blockquote-image.twig
@@ -4,7 +4,7 @@
     <h3>
       <span class="{{ highlight }}">{{ heading }}</span>
     </h3>
-    <p>{{ body_text }}</p>
+    <p>{{ body_text['#text']|spaceless|replace({'</p><p>': '</br>', '<p>': '', '</p>': ''})|raw }}</p>
     {% if citation_author is not empty or citation_description is not empty %}
       <div class="citation">
         <div class="citation-content">


### PR DESCRIPTION
Ticket: https://asudev.jira.com/browse/WS2-1574

This solution includes cases where the user has entered a line break by replacing the occurrence of the `</p><p>` tags with `<br>`

QA Steps:
- Create a blockquote with a single line of text. The opening and closing quotes should appear on the same line as the text.
- Create a blockquote with line breaks.
- Create a blockquote that contains anchors and line breaks.