### PR TITLE
WS-1515 - Added classes to page TWIG to stop super-wide content items

### DIFF
--- a/templates/page/page.html.twig
+++ b/templates/page/page.html.twig
@@ -13,7 +13,7 @@
     {% endif %}
 
     {% if page.pre_content %}
-      <div class="page__pre-content">
+      <div class="page__pre-content center-container max-size-container">
         <div class="container">
           {{ page.pre_content }}
         </div>
@@ -21,7 +21,7 @@
     {% endif %}
 
     {% if page.content %}
-      <div id="skip-to-content" class="page__content">
+      <div id="skip-to-content" class="page__content center-container max-size-container">
         {{ page.content }}
       </div>
     {% endif %}


### PR DESCRIPTION
Simple fix in page.html.twig file caps the width at 1920px and centers those divs. Only blocks put in regions outside the pre-content and content divs in the page template (the global ASU header/footer, megafooter, etc.) will go 100% wide now.