### PR TITLE
WS2-1577 - Removed superfluous padding from 'Card and Image' block

### DIFF
--- a/src/components/image-text-block/_image-text-block.scss
+++ b/src/components/image-text-block/_image-text-block.scss
@@ -1,20 +1,9 @@
 .block-inline-blockimage-and-text-block {
   .uds-image-text-block-text-container {
     padding: $uds-size-spacing-6;
-
     // Recommended by Debbie Flitner.
     :is(h2, h3, h4, h5, h6):first-of-type {
       margin-top: 0;
-    }
-
-    // Workaround recommended by Debbie Flitner.
-    @media screen and (min-width: $uds-breakpoint-lg) {
-      .col-12 {
-        &.py-1 {
-          padding-bottom: 0 !important;
-          padding-top: 0 !important;
-        }
-      }
     }
   }
 }


### PR DESCRIPTION
Fixes button padding issue. See WS2-1577 for more information.

This PR does not include the newly compiled CSS/JS files - only the modified SASS. That will need to be done when the release is being prepared.